### PR TITLE
Make neovim 32bit

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -36,7 +36,7 @@ const download = async () => {
         "tag": "v0.2.2",
         "platforms": {
             "win32": {
-                "name": "nvim-win64.zip"
+                "name": "nvim-win32.zip"
             },
             "darwin": {
                 "name": "nvim-macos.tar.gz"


### PR DESCRIPTION
It says Windows 32 bit so downloading a 64bit version of Neovim makes no sense, it doesn't work on 32bit (#1780). If that isn't the optimal solution for 64bit systems, I would soggest splitting the release into a 32bit and a 64bit version.